### PR TITLE
feat: auto-load callsign from profile config.yaml

### DIFF
--- a/app/components/RetrainProfileModal.vue
+++ b/app/components/RetrainProfileModal.vue
@@ -32,6 +32,7 @@ interface ProfileConfigSlice {
   model: string | null
   provider: string | null
   allowlist: string[]
+  name: string | null
 }
 
 interface ModelOption {
@@ -213,7 +214,7 @@ async function loadAll(slug: string) {
       }),
       $fetch<ProfileConfigSlice>(`/api/profiles/${slug}/config`).catch((e) => {
         toast.add({ title: t('profileConfig.loadFailed'), description: (e as Error).message, color: 'error' })
-        return { model: null, provider: null, allowlist: [] as string[] }
+        return { model: null, provider: null, allowlist: [] as string[], name: null }
       })
     ])
     skills.value = skillList

--- a/server/api/profiles.get.ts
+++ b/server/api/profiles.get.ts
@@ -2,6 +2,7 @@ import { useDb, type ProfileRow } from '../utils/db'
 import { discoverProfiles } from '../utils/hermes'
 import { avatarUrl, defaultSeed, pickColor, type Gesture } from '../utils/avatar'
 import { syncRoster } from '../utils/roster'
+import { readProfileConfig } from '../utils/profile-config'
 
 let rosterPrimed = false
 
@@ -37,6 +38,15 @@ export default defineEventHandler(() => {
       now,
       now
     )
+  }
+
+  // Auto-load callsign from config.yaml (config.yaml overrides database)
+  const updateCallsign = db.prepare('UPDATE profiles SET given_name = ? WHERE slug = ?')
+  for (const p of discovered) {
+    const config = readProfileConfig(p.hermesDir)
+    if (config.name) {
+      updateCallsign.run(config.name, p.slug)
+    }
   }
 
   const rows = db

--- a/server/api/profiles/[slug]/config.put.ts
+++ b/server/api/profiles/[slug]/config.put.ts
@@ -6,6 +6,7 @@ interface PutBody {
   model?: string | null
   provider?: string | null
   allowlist?: unknown
+  name?: string | null
   /** When true, copy the global `model:` block into the profile config so
    *  Hermes sees explicit values. The war-room's "Heredar global" toggle. */
   inheritGlobalModel?: boolean
@@ -39,6 +40,9 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, statusMessage: '`allowlist` must be an array of strings' })
     }
     patch.allowlist = body.allowlist.filter((v): v is string => typeof v === 'string')
+  }
+  if ('name' in body) {
+    if (body.name === null || typeof body.name === 'string') patch.name = body.name
   }
 
   if (Object.keys(patch).length === 0) {

--- a/server/utils/profile-config.ts
+++ b/server/utils/profile-config.ts
@@ -79,6 +79,8 @@ export interface ProfileConfigSlice {
   provider: string | null
   /** command_allowlist — list of dangerous-pattern descriptions pre-approved without prompting. */
   allowlist: string[]
+  /** name — optional display name/callsign for the profile (used by war-room) */
+  name: string | null
 }
 
 function configPath(profileDir: string): string {
@@ -87,23 +89,26 @@ function configPath(profileDir: string): string {
 
 export function readProfileConfig(profileDir: string): ProfileConfigSlice {
   const path = configPath(profileDir)
-  if (!existsSync(path)) return { model: null, provider: null, allowlist: [] }
+  if (!existsSync(path)) return { model: null, provider: null, allowlist: [], name: null }
   try {
     const raw = readFileSync(path, 'utf8')
     const cfg = parseYaml(raw) as {
       model?: { default?: unknown, provider?: unknown }
       command_allowlist?: unknown
+      name?: unknown
     } | null
     const modelDefault = cfg?.model?.default
     const provider = cfg?.model?.provider
+    const name = cfg?.name
     const list = Array.isArray(cfg?.command_allowlist) ? cfg.command_allowlist : []
     return {
       model: typeof modelDefault === 'string' ? modelDefault : null,
       provider: typeof provider === 'string' ? provider : null,
+      name: typeof name === 'string' ? name.trim() : null,
       allowlist: list.filter((v): v is string => typeof v === 'string')
     }
   } catch {
-    return { model: null, provider: null, allowlist: [] }
+    return { model: null, provider: null, allowlist: [], name: null }
   }
 }
 
@@ -111,6 +116,7 @@ export interface ProfileConfigPatch {
   model?: string | null
   provider?: string | null
   allowlist?: string[]
+  name?: string | null
   /** When true, copy the global Hermes `model:` block (default, provider,
    *  base_url, api_key) into this profile's config, overwriting any prior
    *  override. Hermes profiles are NOT inherit-on-miss — they fully shadow
@@ -196,6 +202,14 @@ export function writeProfileConfig(profileDir: string, patch: ProfileConfigPatch
   if (Array.isArray(patch.allowlist)) {
     const cleaned = [...new Set(patch.allowlist.filter(s => typeof s === 'string' && s.trim() !== ''))]
     doc.set('command_allowlist', cleaned)
+  }
+
+  if ('name' in patch) {
+    if (patch.name === null || (typeof patch.name === 'string' && patch.name.trim() === '')) {
+      if (doc.has('name')) doc.delete('name')
+    } else if (typeof patch.name === 'string') {
+      doc.set('name', patch.name.trim())
+    }
   }
 
   // Defensive: if the resulting `command_allowlist` came out as something


### PR DESCRIPTION
Reference:
https://github.com/Naroh091/hermes-war-room/issues/1

Changes:
- Add name field to ProfileConfigSlice and ProfileConfigPatch
- Auto-load callsign from config.yaml name field on profile discovery
- Config.yaml overrides database callsign values
- Update config write endpoint to support name field
- Update RetrainProfileModal interface to include name field

Tests:
- Using a new config.yaml with `name` the property is auto-loaded and saved in database
- Using a new config.yaml without `name` the property is still NULL on database
- Using a different config.yaml with or without `name` the property is being override